### PR TITLE
Add links to Hashicorp Vault account plugin & other acct management tweaks

### DIFF
--- a/docs/HowTo/ManageKeys/AccountPlugins.md
+++ b/docs/HowTo/ManageKeys/AccountPlugins.md
@@ -8,7 +8,7 @@ We recommended reading the [Plugins overview](../../Concepts/Plugins/Plugins.md)
 
 | Name | Version |  | Description |
 | --- | --- | --- | --- |
-| <span style="white-space:nowrap">`hashicorp-vault`</span> | `0.0.1` | <span style="white-space:nowrap">[Docs & Source](https://www.github.com/ConsenSys/quorum-account-plugin-hashicorp-vault)</span> | Enables storage of Quorum account keys in a Hashicorp Vault kv v2 engine.  Written in Go.
+| `hashicorp-vault` | `0.0.1` | [Docs & Source](https://www.github.com/ConsenSys/quorum-account-plugin-hashicorp-vault) | Enables storage of Quorum account keys in a Hashicorp Vault kv v2 engine.  Written in Go.
 
 ## Using with GoQuorum & clef
 

--- a/docs/HowTo/ManageKeys/AccountPlugins.md
+++ b/docs/HowTo/ManageKeys/AccountPlugins.md
@@ -4,6 +4,11 @@
 
 We recommended reading the [Plugins overview](../../Concepts/Plugins/Plugins.md) first to learn how to use plugins.
 
+## Available account plugins
+| Name | Version |  | Description |
+| --- | --- | --- | --- |
+| <span style="white-space:nowrap">`hashicorp-vault`</span> | `0.0.1` | <span style="white-space:nowrap">[Docs & Source](https://www.github.com/ConsenSys/quorum-account-plugin-hashicorp-vault)</span> | Enables storage of Quorum account keys in a Hashicorp Vault kv v2 engine.  Written in Go.
+
 ## Using with GoQuorum & clef
 
 === "Quorum"

--- a/docs/HowTo/ManageKeys/AccountPlugins.md
+++ b/docs/HowTo/ManageKeys/AccountPlugins.md
@@ -5,6 +5,7 @@
 We recommended reading the [Plugins overview](../../Concepts/Plugins/Plugins.md) first to learn how to use plugins.
 
 ## Available account plugins
+
 | Name | Version |  | Description |
 | --- | --- | --- | --- |
 | <span style="white-space:nowrap">`hashicorp-vault`</span> | `0.0.1` | <span style="white-space:nowrap">[Docs & Source](https://www.github.com/ConsenSys/quorum-account-plugin-hashicorp-vault)</span> | Enables storage of Quorum account keys in a Hashicorp Vault kv v2 engine.  Written in Go.
@@ -201,4 +202,5 @@ geth account plugin list \
 ```
 
 ## Developers
+
 See [For Developers](../../Reference/Plugins/account/For-Developers.md).

--- a/docs/HowTo/ManageKeys/ManagingKeys.md
+++ b/docs/HowTo/ManageKeys/ManagingKeys.md
@@ -2,40 +2,14 @@
 
 Options for managing keys in GoQuorum include:
 
-* Keystore files
+* [`keystore` files](https://geth.ethereum.org/docs/interface/managing-your-accounts)
 
-    [As with geth, keys can be stored in password-protected `keystore` files.](https://geth.ethereum.org/docs/interface/managing-your-accounts)
+    As with geth, keys can be stored in password-protected `keystore` files.
 
-* [Clef](#clef)
+* [`clef`](clef.md)
 
-* Accounts plugin
+    Introduced in GoQuorum v2.6.0, `clef` runs as a standalone process that increases flexibility and security by handling GoQuorum's account management responsibilities.
 
-    GoQuorum v2.7.0 introduced [`account` plugins support](AccountPlugins.md), which allows GoQuorum or `clef` to be extended
-   with alternative methods of managing accounts.
+* [`account` plugins](AccountPlugins.md)
 
-## Clef
-
-`clef` was introduced in Quorum `v2.6.0`.
-
-Clef for GoQuorum is the standard `go-ethereum` `clef` tool, with additional support for GoQuorum-specific
-features, including:
-
-* Support for private transactions
-* Ability to extend functionality with [`account` plugins](AccountPlugins.md)
-
-`clef` runs as a separate process to `geth` and provides an alternative method of managing accounts
-and signing transactions/data.  Instead of `geth` loading and using accounts directly, `geth` delegates
-account management responsibilities to `clef`.
-
-Account management will be deprecated within `geth` in the future and replaced with `clef`.
-
-Using `clef` instead of `geth` for account management has several benefits:
-
-* Users and DApps no longer have a dependency on access to a synchronised local node loaded with accounts.
-Transactions and DApp data can instead be signed using `clef`
-* Future account-related features will likely only be available in `clef` and not found in `geth`
-(e.g. [EIP-191 and EIP-712 have been implemented in `clef`, but there is no intention of implementing them in `geth`](https://github.com/ethereum/go-ethereum/pull/17789/))
-* User-experience improvements to ease use and improve security.
-
-
-
+    Introduced in GoQuorum v2.7.0, `account` plugins allow GoQuorum or `clef` to be extended with alternative methods of managing accounts.

--- a/docs/HowTo/ManageKeys/clef.md
+++ b/docs/HowTo/ManageKeys/clef.md
@@ -1,11 +1,38 @@
-# Using Clef 
+# Using Clef
+
+## What is Clef?
+
+`clef` was introduced in Quorum `v2.6.0`.
+
+Clef for GoQuorum is the standard `go-ethereum` `clef` tool, with additional support for GoQuorum-specific
+features, including:
+
+* Support for private transactions
+* Ability to extend functionality with [`account` plugins](AccountPlugins.md)
+
+`clef` runs as a separate process to `geth` and provides an alternative method of managing accounts
+and signing transactions/data.  Instead of `geth` loading and using accounts directly, `geth` delegates
+account management responsibilities to `clef`.
+
+Account management will be deprecated within `geth` in the future and replaced with `clef`.
+
+Using `clef` instead of `geth` for account management has several benefits:
+
+* Users and DApps no longer have a dependency on access to a synchronised local node loaded with accounts.
+
+Transactions and DApp data can instead be signed using `clef`
+
+* Future account-related features will likely only be available in `clef` and not found in `geth`
+(e.g. [EIP-191 and EIP-712 have been implemented in `clef`, but there is no intention of implementing them in `geth`](https://github.com/ethereum/go-ethereum/pull/17789/))
+* User-experience improvements to ease use and improve security.
 
 ## Installing
 
-`geth` and all included tools (i.e. `clef`, `bootnode`, ...) can be installed to `PATH` by 
+`geth` and all included tools (i.e. `clef`, `bootnode`, ...) can be installed to `PATH` by
 [building GoQuorum from source with `make all`](../GetStarted/Install.md).
 
 Verify the installation with:
+
 ```shell
 clef help
 ```
@@ -23,7 +50,7 @@ for an overview and step-by-step guide on initialising and starting `clef`, as w
 1. As a `geth` signer
 
 !!! warning
-    In the long term, the preferred way of using `clef` will be as an external signer.  However, whilst 
+    In the long term, the preferred way of using `clef` will be as an external signer.  However, whilst
     waiting for tooling to support the `clef` API, the `go-ethereum` project have included the option
     to use `clef` as a `geth` signer.  This ensures existing tooling and user flows can remain unchanged.
     The option to use `clef` as a `geth` signer **will be deprecated** in a future release of `go-ethereum`
@@ -39,7 +66,7 @@ An example workflow would be:
 1. Start `clef` and make your accounts available to it
 1. Sign a transaction with the account by using `clef`'s `account_signTransaction` API.  `clef` will return the signed transaction.
 1. Use `eth_sendRawTransaction` or `eth_sendRawPrivateTransaction` to send the signed transaction to a GoQuorum node that does not have your accounts available to it
-1. The GoQuorum node validates the transaction and propagates it through the network for minting.  
+1. The GoQuorum node validates the transaction and propagates it through the network for minting.
 
 #### Example: List accounts
 
@@ -51,7 +78,7 @@ echo '{"id": 1, "jsonrpc": "2.0", "method": "account_list"}' | nc -U /path/to/cl
 
 ```shell
 echo '{"id": 1, "jsonrpc": "2.0", "method": "account_signData", "params": ["data/plain", "0x6038dc01869425004ca0b8370f6c81cf464213b3", "0xaaaaaa"]}' | nc -U /path/to/clef.ipc
-``` 
+```
 
 ### As a geth signer
 
@@ -61,18 +88,18 @@ Using `clef` as a `geth` signer does not require direct interaction through the 
 To use `clef` as a `geth` signer:
 
 1. Start `clef`
-1. Start `geth` with the `--signer /path/to/clef.ipc` CLI flag 
+1. Start `geth` with the `--signer /path/to/clef.ipc` CLI flag
 
 An example workflow would be:
 
 1. Start `clef` and make your accounts available to it
 1. Start `geth` and do not make your accounts available to it
-1. Use `eth_sendTransaction` to sign and submit a transaction for validation, propagation, and minting 
+1. Use `eth_sendTransaction` to sign and submit a transaction for validation, propagation, and minting
 
 ### Extending with account plugins
 
 By default, `clef` manages file-stored `keystore` accounts.  Alternative account management options
-can be enabled through the use of [`account` plugins](AccountPlugins.md).  See the 
+can be enabled through the use of [`account` plugins](AccountPlugins.md).  See the
 [Pluggable Architecture Overview](../../Concepts/Plugins/Plugins.md) for more info on using plugins with `clef`.
 
 ```shell

--- a/docs/Reference/Plugins/account/For-Developers.md
+++ b/docs/Reference/Plugins/account/For-Developers.md
@@ -1,14 +1,14 @@
 # account Plugins: For developers
 
-New `account` plugins can be developed to extend the supported account management options for GoQuorum and `clef`. 
+New `account` plugins can be developed to extend the supported account management options for GoQuorum and `clef`.
 
-`account` plugins must satisfy the [documented gRPC API](interface.md).  
+`account` plugins must satisfy the [documented gRPC API](interface.md).
 
-!!! note 
-    This documentation is auto-generated from the [GoQuorum Plugin Definitions](https://github.com/ConsenSys/quorum-plugin-definitions) `account.proto` file *(available soon)*
+!!! note
+    This documentation is auto-generated from the [GoQuorum Plugin Definitions](https://github.com/ConsenSys/quorum-plugin-definitions) `account.proto` file
 
-To simplify the development of new `account` plugins the following `account` plugin SDKs are available: 
+To simplify the development of new `account` plugins the following `account` plugin SDKs are available:
 
 | Name | Language |
-| --- | --- | 
-| [quorum-account-plugin-sdk-go](https://github.com/ConsenSys/quorum-account-plugin-sdk-go) *(available soon)* | [Go](https://golang.org)
+| --- | --- |
+| [quorum-account-plugin-sdk-go](https://github.com/ConsenSys/quorum-account-plugin-sdk-go) | [Go](https://golang.org)


### PR DESCRIPTION
* Add links to the Hashicorp Vault account plugin impl
* Make info on key management options consistent
* Relocate clef overview to the clef page
* Remove out-of-date "available soon" notes