### PR TITLE
plugin: add Cloudsmith migration changes

### DIFF
--- a/docs/Concepts/Plugins/Plugins.md
+++ b/docs/Concepts/Plugins/Plugins.md
@@ -61,8 +61,8 @@ To disable the plugin verification process, use the
 
 !!! important
 
-    Before `21.4.1`, Quorum's default configuration is to use Bintray as the Plugin Central Server to distribute the official plugins.
-    As Bintray is into sunset on May 1st 2020, please [configure](../../HowTo/Configure/Plugins.md#plugincentralconfiguration) plugin central as below 
+    Before GoQuorum `21.4.1`, the default Plugin Central Server configuration used Bintray to distribute the official plugins.
+    As Bintray will stop working on May 1st 2020, [configure plugin central](../../HowTo/Configure/Plugins.md#plugincentralconfiguration) to use ConsenSys Cloudsmith repository
     to override the default:
     ```json
     {

--- a/docs/Concepts/Plugins/Plugins.md
+++ b/docs/Concepts/Plugins/Plugins.md
@@ -59,6 +59,21 @@ To disable the plugin verification process, use the
 
     Using `--plugins.skipverify` introduces security risks and isn't recommended for production environments.
 
+!!! important
+
+    Before `21.4.1`, Quorum's default configuration is to use Bintray as the Plugin Central Server to distribute the official plugins.
+    As Bintray is into sunset on May 1st 2020, please [configure](../../HowTo/Configure/Plugins.md#plugincentralconfiguration) plugin central as below 
+    to override the default:
+    ```json
+    {
+        "central": {
+            "baseURL": "https://provisional-plugins-repo.quorum.consensys.net",
+            "publicKeyURI": ".pgp/Central.pgp.pk"
+        },
+        ...
+    }
+    ```
+
 ## Example: `HelloWorld` plugin
 
 The plugin interface is implemented in Go and Java. In this example, `HelloWorld` plugin exposes a JSON RPC endpoint

--- a/docs/HowTo/Configure/Plugins.md
+++ b/docs/HowTo/Configure/Plugins.md
@@ -50,7 +50,9 @@ Modifying this section configures your own local plugin central for Plugin Integ
       "baseURL": string,
       "certFingerprint": string,
       "publicKeyURI": string,
-      "insecureSkipTLSVerify": bool
+      "insecureSkipTLSVerify": bool,
+      "pluginDistPathTemplate": string,
+      "pluginSigPathTemplate": string
     }
     ```
 
@@ -61,6 +63,8 @@ Modifying this section configures your own local plugin central for Plugin Integ
     CertFingerPrint = string
     PublicKeyURI = string
     InsecureSkipTLSVerify = bool
+    PluginDistPathTemplate = string
+    PluginSigPathTemplate = string
     ```
 
 | Fields                  | Description                                                                                                               |
@@ -69,6 +73,8 @@ Modifying this section configures your own local plugin central for Plugin Integ
 | `certFingerprint`       | A string containing hex representation of the http server public key finger print <br/>to be used for certificate pinning |
 | `publicKeyURI`          | A string defining the location of the PGP public key <br/>to be used to perform the signature verification                |
 | `insecureSkipTLSVerify` | If true, **do not** verify the server's certificate chain and host name                                                   |
+| `pluginDistPathTemplate`| A string defining the path template to the plugin distribution file. <br/>The value is a string that is a Go text template. <br/>The self-explanatory variables are \{\{.Name\}\}, \{\{.Version\}\}, \{\{.OS\}\} and \{\{.Arch\}\} |
+| `pluginSigPathTemplate` | A string defining the path template to the plugin sha256 signature file. <br/> The value is a string that is a Go text template. <br/>The self-explanatory variables are \{\{.Name\}\}, \{\{.Version\}\}, \{\{.OS\}\} and \{\{.Arch\}\} |
 
 ## `PluginDefinition`
 


### PR DESCRIPTION
Bintray is sunsetting on May 1st 2020. This is to update plugin doc to reflect changes in https://github.com/ConsenSys/quorum/pull/1174
