### PR TITLE
add pliny doc team as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @ConsenSys/protocol-pliny


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## Pull Request Description

Add the documentation team @ConsenSys/protocol-pliny as code owner for all the doc code so at least one member of the team is required to review PRs. In the past, some PR were merged without a review from doc team and even if all test passed correctly, some content was not displayed correctly. Doc team can help checking that.

Also updates the submodule.