### PR TITLE
doc missing CLI options

### DIFF
--- a/docs/HowTo/Use/JSON-RPC-API-Security.md
+++ b/docs/HowTo/Use/JSON-RPC-API-Security.md
@@ -68,17 +68,15 @@ curl -X POST -H "Content-type: application/json" -H "Authorization: $TOKEN" \
 
 ### `geth attach`
 
-Use command line options to allow a secured GoQuorum node connection:
+Use the following command line options to allow a secured GoQuorum node connection:
 
-```text
---rpcclitoken value                 RPC Client access token
---rpcclitls.insecureskipverify      Disable verification of server's TLS certificate on connection by client
---rpcclitls.cert value              Server's TLS certificate PEM file on connection by client
---rpcclitls.cacert value            CA certificate PEM file for provided server's TLS certificate on connection by client
---rpcclitls.ciphersuites value      Customize supported cipher suites when using TLS connection. Value is a comma-separated cipher suite string
-```
+- [`--rpcclitoken`](../../Reference/CLI-Syntax.md#rpcclitoken)
+- [`--rpcclitls.insecureskipverify`](../../Reference/CLI-Syntax.md#rpcclitlsinsecureskipverify)
+- [`--rpcclitls.cert`](../../Reference/CLI-Syntax.md#rpcclitlscert)
+- [`--rpcclitls.cacert`](../../Reference/CLI-Syntax.md#rpcclitlscacert)
+- [`--rpcclitls.ciphersuites`](../../Reference/CLI-Syntax.md#rpcclitlsciphersuites)
 
-For example, connect to the node with `--rpcclitls.insecureskipverify` to ignore the server's certificate validation:
+For example, connect to the node using `--rpcclitls.insecureskipverify` to ignore the server's certificate validation:
 
 === "HTTP"
 

--- a/docs/Reference/CLI-Syntax.md
+++ b/docs/Reference/CLI-Syntax.md
@@ -138,7 +138,6 @@ Custom fork block when using [IBFT](../HowTo/Configure/Consensus-Protocols/IBFT.
 [QBFT](../HowTo/Configure/Consensus-Protocols/QBFT.md) consensus.
 The default is 0.
 
-
 ### `permissioned`
 
 === "Syntax"

--- a/docs/Reference/CLI-Syntax.md
+++ b/docs/Reference/CLI-Syntax.md
@@ -32,6 +32,16 @@ Maximum time from current time allowed for blocks before they're considered futu
 This allows nodes to be slightly out of sync without receiving "Mining too far in the future" messages.
 The default is 0.
 
+### `emitcheckpoints`
+
+=== "Syntax"
+
+    ```bash
+    --emitcheckpoints
+    ```
+
+If included, emits specially formatted logging checkpoints.
+
 ### `immutabilitythreshold`
 
 === "Syntax"
@@ -109,6 +119,25 @@ The default is 10000.
 
 Enables [multi-tenancy](../Concepts/Multitenancy/Overview.md).
 This requires the [JSON-RPC Security plugin](../HowTo/Use/JSON-RPC-API-Security.md) to also be configured.
+
+### `override.istanbul`
+
+=== "Syntax"
+
+    ```bash
+    --override.istanbul <INTEGER>
+    ```
+
+=== "Example"
+
+    ```bash
+    --override.istanbul 100
+    ```
+
+Custom fork block when using [IBFT](../HowTo/Configure/Consensus-Protocols/IBFT.md) or
+[QBFT](../HowTo/Configure/Consensus-Protocols/QBFT.md) consensus.
+The default is 0.
+
 
 ### `permissioned`
 
@@ -313,7 +342,7 @@ The default is 5 seconds.
     ---ptm.tls.clientcert client.cert.pem
     ```
 
-Path to the file containing client certificate (or chain of certificates) when using a TLS
+Path to the file containing the client certificate (or chain of certificates) when using a TLS
 [connection to the private transaction manager](../HowTo/Configure/ConfigurePTM.md).
 This is required if the server is configured to use two-way authentication.
 
@@ -377,7 +406,7 @@ Setting to `strict` enables TLS when using an HTTPS [connection to the private t
     ---ptm.tls.rootca certfile.pem
     ```
 
-Path to the file containing root CA certificate when using a TLS [connection to the private transaction manager](../HowTo/Configure/ConfigurePTM.md).
+Path to the file containing the root CA certificate when using a TLS [connection to the private transaction manager](../HowTo/Configure/ConfigurePTM.md).
 The default is the host's certificates.
 
 ### `ptm.url`
@@ -513,3 +542,95 @@ The default is 50400.
 
 Enables including the [revert reason](../HowTo/Use/Revert-Reason.md) in the
 [`eth_getTransactionReceipt`](https://eth.wiki/json-rpc/API#eth_gettransactionreceipt) response.
+
+### `rpcclitls.cacert`
+
+=== "Syntax"
+
+    ```bash
+    --rpcclitls.cacert <path>/<to>/<TLS-CA-pem-file>
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpcclitls.cacert certfile.pem
+    ```
+
+Path to the file containing the CA certificate for the [server's TLS certificate](#rpcclitlscert) when using a
+[secured GoQuorum node connection](../HowTo/Use/JSON-RPC-API-Security.md).
+
+### `rpcclitls.cert`
+
+=== "Syntax"
+
+    ```bash
+    --rpcclitls.cert <path>/<to>/<TLS-pem-file>
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpcclitls.cert certfile.pem
+    ```
+
+Path to the file containing the server's TLS certificate when using a [secured GoQuorum node connection](../HowTo/Use/JSON-RPC-API-Security.md).
+
+### `rpcclitls.ciphersuites`
+
+=== "Syntax"
+
+    ```bash
+    --rpcclitls.ciphersuites <STRING>
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpcclitls.ciphersuites "CIPHER_SUITE_1,CIPHER_SUITE_2"
+    ```
+
+Comma-separated list of cipher suites to support when using a [secured GoQuorum node connection](../HowTo/Use/JSON-RPC-API-Security.md).
+
+### `rpcclitls.insecureskipverify`
+
+=== "Syntax"
+
+    ```bash
+    --rpcclitls.insecureskipverify
+    ```
+
+If included, disables verification of the server's TLS certificate when using a [secured GoQuorum node connection](../HowTo/Use/JSON-RPC-API-Security.md).
+
+### `rpcclitoken`
+
+=== "Syntax"
+
+    ```bash
+    --rpcclitoken <STRING>
+    ```
+
+=== "Example"
+
+    ```bash
+    --rpcclitoken "AYjcyMzY3ZDhiNmJkNTY"
+    ```
+
+JSON-RPC client access token when using a [secured GoQuorum node connection](../HowTo/Use/JSON-RPC-API-Security.md).
+
+### `vm.calltimeout`
+
+=== "Syntax"
+
+    ```bash
+    --vm.calltimeout <INTEGER>
+    ```
+
+=== "Example"
+
+    ```bash
+    --vm.calltimeout 2
+    ```
+
+Timeout in seconds when executing [`eth_call`](https://geth.ethereum.org/docs/rpc/ns-eth#eth_call).
+The default is 5.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/doc.ethsigner/blob/master/CONTRIBUTING.md -->

## Pull Request Description

Doc GoQuorum specific CLI options previously missing from docs:

- `--rpccli*` options
-  `--emitcheckpoints`
- `--vm.calltimeout`
- `--override.istanbul`

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes ES-<Jira issue number> -->
<!-- Example: "fixes ES-1234" -->

fixes #152 

## Preview

see https://pegasys-docgoquorum--155.com.readthedocs.build/en/155/Reference/CLI-Syntax/