### PR TITLE
Clarify revert reason cli args behaviour

### DIFF
--- a/docs/configure-and-manage/manage/revert-reason.md
+++ b/docs/configure-and-manage/manage/revert-reason.md
@@ -30,8 +30,8 @@ client an optional string message containing information about the error.
 
 ## Enabling revert reason
 
-Use the [`--revertreason`](../../reference/cli-syntax.md#revertreason)
-command line option to include the revert reason in the transaction receipt.
+Restart you GoQuorum node with the [`--revertreason`](../../reference/cli-syntax.md#revertreason) command line option enabled. 
+Any subsequent reverted transactions will have the revert reason stored locally.
 
 ## Where is the revert reason included
 


### PR DESCRIPTION
## Describe the change

Enabling the revert reason is done using cli args. The result will show up in `eth_getTransactionReceipt` without changing any params on the request.

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content
- [ ] Documentation page organization

For tool changes:

- [ ] Build and QA tools (e.g., lint)
- [ ] MkDocs templates
- [ ] MkDocs configuration
- [ ] Python dependencies
- [ ] Node dependencies and JavaScript
- [ ] GitHub integration

## After creating your PR and tests have finished

Make sure that:

- [ ] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [ ] You've [previewed your changes on GitHub Pages](https://consensys.net/docs/doctools/en/latest/preview/new-system/#preview-on-github-pages)
