### PR TITLE
Add information about berlin hard fork upgrade

### DIFF
--- a/docs/deploy/upgrade/migration.md
+++ b/docs/deploy/upgrade/migration.md
@@ -15,6 +15,14 @@ Check that the node starts without errors and has the latest block from the netw
 We don't recommend jumping versions during an upgrade; some versions require manual intervention.
 Check the [release log](https://github.com/ConsenSys/quorum/releases) for any actions you might need to take.
 
+## Upgrade to GoQuorum 22.4.1 - ⚠️ Berlin Hard Fork ⚠️
+
+When upgrading to and past this version, you need to specify `berlinBlock` in your genesis and run `geth init` again. The block needs to be sufficiently in the future to allow **ALL** your nodes in the network to upgrade before that block height is reached.
+
+If you upgrade to this version and do not specify a value for `berlinBlock` it will default to `0`. So your network may work for a while, but if you need to resync your node, it will result in a forked state with a `Bad block error`.
+
+More details about EIPs included in this upgrade and how they impact gas calculations. https://blog.ethereum.org/2021/03/08/ethereum-berlin-upgrade-announcement/
+
 ## Upgrade to GoQuorum 22.1.0
 
 There are [several significant changes to the underlying Geth 1.10](https://blog.ethereum.org/2021/03/03/geth-v1-10-0/)

--- a/docs/deploy/upgrade/migration.md
+++ b/docs/deploy/upgrade/migration.md
@@ -15,11 +15,19 @@ Check that the node starts without errors and has the latest block from the netw
 We don't recommend jumping versions during an upgrade; some versions require manual intervention.
 Check the [release log](https://github.com/ConsenSys/quorum/releases) for any actions you might need to take.
 
+## Upgrade to GoQuorum 22.7.0 - ⚠️ Berlin Hard Fork ⚠️
+
+When upgrading to and past this version, you should specify a block for `berlinBlock` if you wish to continue using snap sync.
+
+!!! warning
+
+    If you are using any privacy features you must use `--syncmode full`
+
 ## Upgrade to GoQuorum 22.4.1 - ⚠️ Berlin Hard Fork ⚠️
 
-When upgrading to and past this version, you need to specify a block for `berlinBlock` as the [milestone block in your genesis file](../../reference/genesis.md#milestone-blocks) and run `geth init` again. The block needs to be sufficiently in the future to allow **ALL** your nodes in the network to upgrade before that block height is reached.
+When upgrading to and past this version, you can specify a block for `berlinBlock` as the [milestone block in your genesis file](../../reference/genesis.md#milestone-blocks) and run `geth init` again. The block needs to be sufficiently in the future to allow **ALL** your nodes in the network to upgrade before that block height is reached.
 
-If you do not specify a value for `berlinBlock`, the default is `0`. So your network might work for a while, but if you need to resync your node, it results in a forked state with a `Bad block error`.
+If you do not specify a value for `berlinBlock`, it will not be applied. However, specifying a `berlinBlock` is required for some features to continue you working (e.g snap sync)
 
 For more details about EIPs included in this upgrade and how they impact gas calculations, refer to the [Ethereum blog](https://blog.ethereum.org/2021/03/08/ethereum-berlin-upgrade-announcement/).
 

--- a/docs/deploy/upgrade/migration.md
+++ b/docs/deploy/upgrade/migration.md
@@ -17,11 +17,11 @@ Check the [release log](https://github.com/ConsenSys/quorum/releases) for any ac
 
 ## Upgrade to GoQuorum 22.4.1 - ⚠️ Berlin Hard Fork ⚠️
 
-When upgrading to and past this version, you need to specify `berlinBlock` in your genesis and run `geth init` again. The block needs to be sufficiently in the future to allow **ALL** your nodes in the network to upgrade before that block height is reached.
+When upgrading to and past this version, you need to specify a block for `berlinBlock` as the [milestone block in your genesis file](../../reference/genesis.md#milestone-blocks) and run `geth init` again. The block needs to be sufficiently in the future to allow **ALL** your nodes in the network to upgrade before that block height is reached.
 
-If you upgrade to this version and do not specify a value for `berlinBlock` it will default to `0`. So your network may work for a while, but if you need to resync your node, it will result in a forked state with a `Bad block error`.
+If you do not specify a value for `berlinBlock`, the default is `0`. So your network might work for a while, but if you need to resync your node, it results in a forked state with a `Bad block error`.
 
-More details about EIPs included in this upgrade and how they impact gas calculations. https://blog.ethereum.org/2021/03/08/ethereum-berlin-upgrade-announcement/
+For more details about EIPs included in this upgrade and how they impact gas calculations, refer to the [Ethereum blog](https://blog.ethereum.org/2021/03/08/ethereum-berlin-upgrade-announcement/).
 
 ## Upgrade to GoQuorum 22.1.0
 


### PR DESCRIPTION
## Describe the change

When upgrading past GoQuorum 22.4.1 the user needs to add some info about `berlinBlock` in their genesis.

## Impacted parts

<!-- Check the item from the following lists that your PR impacts. You can check multiple boxes. -->

For content changes:

- [x] Documentation content

## After creating your PR and tests have finished

Make sure that:

- [x] You've [fixed any issues](https://consensys.net/docs/doctools/en/latest/contribute/fix-cicd-errors/) raised by the tests.
- [x] You've [previewed your changes on GitHub Pages](https://consensys.net/docs/doctools/en/latest/preview/new-system/#preview-on-github-pages)
