### PR TITLE
fix: github icon link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -158,7 +158,7 @@ const config = {
           },
 
           {
-            href: "https://github.com/ConsenSys/goquorum",
+            href: "https://github.com/ConsenSys/quorum",
             className: "header-github-link",
             position: "right",
           },


### PR DESCRIPTION
- github icon link to correct repo

Fixes #260